### PR TITLE
[BUG] #12 Article empty field

### DIFF
--- a/routes/article.ctl.js
+++ b/routes/article.ctl.js
@@ -56,6 +56,11 @@ const post = {
     post: async (req, res) => {
         const article = req.body;
 
+        if(!req.body.author || !req.body.content) {
+            res.status(400)
+            res.send({ success: false, result: "post body author or content is undefined or null."});
+            return;
+        }
         article['like'] = 0;
         
         const articles = await getArticles();

--- a/routes/article.js
+++ b/routes/article.js
@@ -8,7 +8,7 @@ router.get("/", (req, res) =>{
   });
 router.get('/article', ctrl.get.list);
 router.get('/article/post', ctrl.get.post);
-router.post('/article/post_error', ctrl.post.post);
+router.post('/article/post', ctrl.post.post);
 router.post('/article/like/:id', ctrl.post.like);
 
 module.exports = router;


### PR DESCRIPTION
…ticle post

작성자: @2tle

fix #12

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 아티클 라우터에 설정된 url의 오타를 수정하였습니다.
- 아티클 생성 컨트롤러에 body값이 비어 있으면 400을 리턴하도록 수정하였습니다.

## 비고

- 아티클 url를 `/article/post_error` 에서 `/article/post` 로 수정함.
- body에 author 또는 content 값 중 하나라도 없는경우 `400`을 반환하며,  
`{ success: false, result: "post body.....null." }` 가 리턴됩니다. 